### PR TITLE
printToConsole method

### DIFF
--- a/HappyBrackets/src/main/java/net/happybrackets/extras/assignment_autograding/BeadsChecker.java
+++ b/HappyBrackets/src/main/java/net/happybrackets/extras/assignment_autograding/BeadsChecker.java
@@ -25,6 +25,24 @@ public class BeadsChecker {
 
     public interface BeadsCheckable {
         public void task(AudioContext ac, StringBuffer buf, Object... args);
+
+        static void printToConsole(StringBuffer buf) { printToConsole(buf, 200); }
+        static void printToConsole(StringBuffer buf, int millis) {
+            new Thread(() -> {
+                int bufPos = 0;
+                while (true) {
+                    String newText = buf.substring(bufPos);
+                    bufPos += newText.length();
+                    System.out.print(newText);
+
+                    try {
+                        Thread.sleep(millis);
+                    } catch (InterruptedException e) {
+                        return;
+                    }
+                }
+            }).start();
+        }
     }
 
     public interface BeadsCheckerFunction {


### PR DESCRIPTION
added printToConsole(StringBuffer) method to BeadsChecker.BeadsCheckable interface

would something like this work? then in each code task start() method just do `BeadsChecker.BeadsCheckable.printToConsole(buf)`

or would there be a better place for it? I was thinking in the BeadsCheckable interface since it's kind of part of that architecture, but a little sad we still need to refer to it by the containing interface name.